### PR TITLE
Volume / Controls / Performance changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,5 +331,6 @@ __pycache__
 # Claude Code / AI-assistant working files -- never ship to the public repo.
 /.claude/
 /PICKUP.md
+/RELEASING.md
 CLAUDE.md
 AGENTS.md

--- a/apps/action.c
+++ b/apps/action.c
@@ -998,7 +998,7 @@ static int global_volume_action(int button, int action)
 /* Trimpod: tap vs. hold on the BACK/SELECT buttons.
  *
  * A quick tap runs the primary action on release (back / select).  Holding the
- * button for 750 ms runs the *secondary* action WHILE STILL HELD -- fired once
+ * button for 650 ms runs the *secondary* action WHILE STILL HELD -- fired once
  * off the auto-repeat the button driver emits for any held button -- and the
  * eventual release is then swallowed so it does not also run the primary.
  *
@@ -1008,7 +1008,7 @@ static int global_volume_action(int button, int action)
  * "abort" in the keyboard; A is rewritten only on screens that actually have a
  * context menu -- the list-style screens, and Now Playing (tap = play/pause,
  * hold = the Now Playing menu). */
-#define TP_HOLD_TICKS   (3*HZ/4)    /* a "hold" is 750 ms */
+#define TP_HOLD_TICKS   (65*HZ/100)  /* a "hold" is 650 ms */
 #define TP_CTX_BASE(c)  ((c) & 0x00ffffff)   /* context minus the flag bits */
 
 /* Shared tap/hold engine.  `btn` is the bare button (BUTTON_A/BUTTON_B); returns

--- a/apps/action.c
+++ b/apps/action.c
@@ -998,7 +998,7 @@ static int global_volume_action(int button, int action)
 /* Trimpod: tap vs. hold on the BACK/SELECT buttons.
  *
  * A quick tap runs the primary action on release (back / select).  Holding the
- * button for a second runs the *secondary* action WHILE STILL HELD -- fired once
+ * button for 750 ms runs the *secondary* action WHILE STILL HELD -- fired once
  * off the auto-repeat the button driver emits for any held button -- and the
  * eventual release is then swallowed so it does not also run the primary.
  *
@@ -1008,7 +1008,7 @@ static int global_volume_action(int button, int action)
  * "abort" in the keyboard; A is rewritten only on screens that actually have a
  * context menu -- the list-style screens, and Now Playing (tap = play/pause,
  * hold = the Now Playing menu). */
-#define TP_HOLD_TICKS   HZ          /* a "hold" is one second */
+#define TP_HOLD_TICKS   (3*HZ/4)    /* a "hold" is 750 ms */
 #define TP_CTX_BASE(c)  ((c) & 0x00ffffff)   /* context minus the flag bits */
 
 /* Shared tap/hold engine.  `btn` is the bare button (BUTTON_A/BUTTON_B); returns
@@ -1030,7 +1030,7 @@ static int tp_hold(int button, int action, int btn, int secondary,
         if (!*fired && *tick != 0 && current_tick - *tick >= TP_HOLD_TICKS)
         {
             *fired = true;
-            return secondary;                   /* fire the hold at ~1s, held */
+            return secondary;                   /* fire the hold, still held */
         }
         return ACTION_NONE;                      /* swallow the auto-repeats */
     }

--- a/apps/gui/skin_engine/skin_display.c
+++ b/apps/gui/skin_engine/skin_display.c
@@ -638,8 +638,8 @@ bool skin_has_sbs(struct gui_wps *gwps)
     return draw;
 }
 
-/* do the button loop as often as required for the peak meters to update
- * with a good refresh rate.
+/* Wait for a button, driving the audio spectrum at SPECTRUM_FPS meanwhile.
+ * Returns as soon as a button arrives, or when `timeout` ticks have passed.
  */
 int skin_wait_for_action(enum skinnable_screens skin, int context, int timeout)
 {
@@ -653,6 +653,11 @@ int skin_wait_for_action(enum skinnable_screens skin, int context, int timeout)
            spectrum = true;
     }
 
+    /* A dark panel shows no spectrum: fall through to the plain blocking wait
+     * rather than spinning every tick to animate something invisible. */
+    if (lcd_panel_is_dark())
+        spectrum = false;
+
     if (spectrum) {
         long next_refresh = current_tick;
         long next_big_refresh = current_tick + timeout;
@@ -665,17 +670,27 @@ int skin_wait_for_action(enum skinnable_screens skin, int context, int timeout)
              * GUI_EVENT_ACTIONUPDATE -> sb_skin_update (so the SBS is repainted
              * into the framebuffer here), and the spectrum redraw below draws
              * into the same framebuffer; we then present exactly ONCE per
-             * frame, with the SBS and the spectrum composited together. */
+             * frame, with the SBS and the spectrum composited together.
+             *
+             * Wait for the next frame's deadline rather than polling every tick:
+             * each extra wake repaints the whole SBS for no extra present.  The
+             * timed wait still returns the instant a button arrives, so this is
+             * no less responsive than the poll it replaces. */
+            long wait = next_refresh - current_tick;
+            if (wait < 0)
+                wait = 0;   /* frame is due: don't block, refresh below */
+
             lcd_set_update_suppressed(true);
-            button = get_action(context,TIMEOUT_NOBLOCK);
+            button = get_action(context, wait);
             if (button != ACTION_NONE) {
                 lcd_set_update_suppressed(false);
                 break;
             }
-            sleep(0);   /* Sleep until end of current tick. */
 
+            /* ">=", not ">": waking exactly on the deadline must refresh, else
+             * the zero-length wait above would spin until the tick rolled over. */
             bool refreshed = false;
-            if (TIME_AFTER(current_tick, next_refresh)) {
+            if (!TIME_BEFORE(current_tick, next_refresh)) {
                 FOR_NB_SCREENS(i)
                 {
                     if(skin_get_gwps(skin, i)->data->spectrum_enabled)

--- a/apps/gui/wps.c
+++ b/apps/gui/wps.c
@@ -591,7 +591,12 @@ static int wps_page_poll(struct trimpod_page *p, int timeout)
     if (w->button && !IS_SYSEVENT(w->button) )
         storage_spin();
 
-    long button = skin_wait_for_action(WPS, CONTEXT_WPS|ALLOW_SOFTLOCK, HZ/5);
+    /* 5Hz keeps the counters/progress bar live on screen; while the panel is
+     * dark drop to 1Hz -- each pass redraws the whole WPS (art, spectrum, text)
+     * into the framebuffer, and nobody is looking.  A button still returns
+     * immediately, and 1s-stale content on wake is imperceptible. */
+    long button = skin_wait_for_action(WPS, CONTEXT_WPS|ALLOW_SOFTLOCK,
+                                       lcd_panel_is_dark() ? HZ : HZ/5);
 
     /* Exit if audio has stopped playing. This happens e.g. at end of
        playlist or if using the sleep timer. */

--- a/apps/gui/wps.c
+++ b/apps/gui/wps.c
@@ -851,14 +851,11 @@ static enum trimpod_page_result wps_page_on_action(struct trimpod_page *p,
                 skin_request_full_update(CUSTOM_STATUSBAR); /* if SBS is used */
                 break;
             case ACTION_NONE: /* Timeout, do a partial update */
-                /* Auto-start the visualizer after the configured idle (while
-                 * music is playing) on Now Playing.  0 = Never. */
-                if (global_settings.viz_start_delay > 0
-                    && !power_display_off()   /* suspended while display blanked */
-                    && (audio_status() & AUDIO_STATUS_PLAY)
-                    && !(audio_status() & AUDIO_STATUS_PAUSE)
-                    && TIME_AFTER(current_tick, button_last_activity_tick()
-                                  + global_settings.viz_start_delay * HZ))
+                /* Auto-start the visualizer after the configured idle while
+                 * music plays (0 = Never).  Runs the sequence inline rather
+                 * than via trimpod_visualizer_maybe_autostart() because the
+                 * skin must be left/restored around the run. */
+                if (trimpod_visualizer_autostart_due())
                 {
                     /* Fade Now Playing to black first (hides the viz load).  A
                      * keypress during the fade cancels -> stay here. */
@@ -939,7 +936,17 @@ long gui_wps_show(void)
     wps_state_init();
 
     trimpod_page_run(&w.base);
-    return w.base.home ? GO_TO_ROOT : w.result;
+    if (w.base.home)
+    {
+        /* Hold-B home: the run loop breaks out before on_action can leave the
+         * skin.  w.restore doubles as "the skin is currently left" -- leave
+         * when still entered, and also after a themeless leave (NOSBS hotkey),
+         * whose viewportmanager theme push is still outstanding. */
+        if (!w.restore || !w.theme_enabled)
+            gwps_leave_wps(true);
+        return GO_TO_ROOT;
+    }
+    return w.result;
 }
 
 struct wps_state *get_wps_state(void)

--- a/apps/lang/english.lang
+++ b/apps/lang/english.lang
@@ -11517,6 +11517,20 @@
   </voice>
 </phrase>
 <phrase>
+  id: LANG_TRIMPOD_CONTROLS
+  desc: Trimpod Controls submenu (in Settings)
+  user: core
+  <source>
+    *: "Controls"
+  </source>
+  <dest>
+    *: "Controls"
+  </dest>
+  <voice>
+    *: "Controls"
+  </voice>
+</phrase>
+<phrase>
   id: LANG_TRIMPOD_ABOUT
   desc: Trimpod About submenu (in Settings)
   user: core

--- a/apps/menu.c
+++ b/apps/menu.c
@@ -42,6 +42,7 @@
 #include "option_select.h"
 #include "trimpod_transition.h"   /* page slide transitions (shared) */
 #include "trimpod_page.h"         /* trimpod_home_pending (hold-BACK -> root) */
+#include "trimpod_visualizer.h"   /* idle auto-start while music plays */
 #include "screens.h"
 #include "lang.h"
 #include "misc.h"
@@ -438,6 +439,11 @@ int do_menu(const struct menu_item_ex *start_menu, int *start_selected,
 
         /* query audio status to see if it changed */
         redraw_lists = query_audio_status(&old_audio_status);
+
+        /* Idle auto-start of the visualizer while music plays (the WPS runs
+         * its own inline hook -- it restores the skin around it). */
+        if (action == ACTION_NONE && trimpod_visualizer_maybe_autostart())
+            redraw_lists = true;
 
         int new_action = menu_callback(action, menu, &lists);
         if (new_action == ACTION_EXIT_AFTER_THIS_MENUITEM)

--- a/apps/menus/main_menu.c
+++ b/apps/menus/main_menu.c
@@ -107,10 +107,17 @@ MAKE_MENU(manage_settings, ID2P(LANG_MANAGE_MENU), NULL, Icon_Config,
 /**********************************/
 
 
-/* About: a scrollable credits list (title from %Lt; scroll with up/down, B exits). */
+/* About: a self-scrolling credits reel (B exits). */
 static int trimpod_about_page(void)
 {
     trimpod_about();
+    return 0;
+}
+
+/* Controls: a static list of the app's inputs (B exits). */
+static int trimpod_controls_page(void)
+{
+    trimpod_controls();
     return 0;
 }
 
@@ -127,11 +134,13 @@ MENUITEM_FUNCTION(tp_set_viz, MENU_SHOW_CHEVRON, ID2P(LANG_TRIMPOD_AUDIO_VISUALI
                   trimpod_av_page, NULL, Icon_NOICON);
 MENUITEM_FUNCTION(tp_set_power, MENU_SHOW_CHEVRON, ID2P(LANG_TRIMPOD_DEVICE),
                   trimpod_power_page, NULL, Icon_NOICON);
+MENUITEM_FUNCTION(tp_set_controls, MENU_SHOW_CHEVRON, ID2P(LANG_TRIMPOD_CONTROLS),
+                  trimpod_controls_page, NULL, Icon_NOICON);
 MENUITEM_FUNCTION(tp_set_about, MENU_SHOW_CHEVRON, ID2P(LANG_TRIMPOD_ABOUT),
                   trimpod_about_page, NULL, Icon_NOICON);
 MAKE_MENU(trimpod_settings_menu, ID2P(LANG_SETTINGS), NULL, Icon_Submenu_Entered,
           &tp_set_mainmenu, &tp_set_audio, &tp_set_viz, &sound_settings, &tp_set_power,
-          &tp_set_about);
+          &tp_set_controls, &tp_set_about);
 int trimpod_settings_page(void)
 {
     do_menu(&trimpod_settings_menu, NULL, NULL, false);

--- a/apps/misc.c
+++ b/apps/misc.c
@@ -578,7 +578,11 @@ static void update_norm_tab(void)
     norm_tab[0] = min;
     norm_tab_size = 1;
 
-    for (int i = 1; i < lim - 1; ++i)
+    /* Trimpod: iterate to lim-1, not lim-2.  The upstream bound skipped the
+     * next-to-top normalized index, leaving a double-width gap so the final step
+     * before max was ~2x -- the main source of the uneven bar/loudness at the
+     * top of the dial. */
+    for (int i = 1; i < lim; ++i)
     {
         int vol = from_normalized_volume(i, min, max, lim);
         int rem = vol % step;

--- a/apps/playlist_viewer.c
+++ b/apps/playlist_viewer.c
@@ -31,7 +31,6 @@
 #include "screens.h"
 #include "settings.h"
 #include "icons.h"
-#include "menu.h"
 #include "scratch_buf.h"
 #include "keyboard.h"
 #include "filetypes.h"
@@ -48,12 +47,11 @@
 #include "icon.h"
 #include "list.h"
 #include "splash.h"
-#include "playlist_menu.h"
-#include "menus/exported_menus.h"
-#include "yesno.h"
 #include "playback.h"
+#include "file.h"                 /* truncate an emptied playlist on autosave */
 #include "trimpod_transition.h"   /* slide the viewer in/out like every other screen */
 #include "trimpod_page.h"         /* trimpod_home_pending (hold-BACK -> root) */
+#include "trimpod_ui.h"           /* the Hold-A context menu */
 #include "trimpod_visualizer.h"   /* idle auto-start while music plays */
 
 
@@ -93,13 +91,9 @@ enum direction
 
 /* Describes possible outcomes from context (menu or hotkey) action          */
 enum pv_context_result {
-    PV_CONTEXT_CLOSED,          /* Playlist Viewer has been closed           */
     PV_CONTEXT_USB,             /* USB-connection initiated                  */
-    PV_CONTEXT_USB_CLOSED,      /* USB-connection initiated (+viewer closed) */
-    PV_CONTEXT_WPS_CLOSED,      /* WPS requested (+viewer closed)            */
     PV_CONTEXT_MODIFIED,        /* Playlist was modified in some way         */
     PV_CONTEXT_UNCHANGED,       /* No change to playlist, as far as we know  */
-    PV_CONTEXT_PL_UPDATE,       /* Playlist buffer requires reloading        */
 };
 
 struct playlist_buffer
@@ -386,7 +380,7 @@ static bool update_playlist(bool force)
 /* Initialize the playlist viewer. */
 static bool playlist_viewer_init(struct playlist_viewer * viewer,
                                  const char* dir, const char* file,
-                                 bool reload, int *recent_selection)
+                                 int *recent_selection)
 {
     char *buffer, *index_buffer = NULL;
     size_t buffer_size, index_buffer_size = 0;
@@ -449,13 +443,10 @@ static bool playlist_viewer_init(struct playlist_viewer * viewer,
     viewer->moving_playlist_index = -1;
     viewer->initial_selection = recent_selection;
 
-    if (!reload)
-    {
-        if (viewer->playlist)
-            viewer->selected_track = recent_selection ? *recent_selection : 0;
-        else
-            viewer->selected_track = playlist_get_display_index() - 1;
-    }
+    if (viewer->playlist)
+        viewer->selected_track = recent_selection ? *recent_selection : 0;
+    else
+        viewer->selected_track = playlist_get_display_index() - 1;
 
     if (!update_playlist(true))
         return false;
@@ -569,25 +560,31 @@ static enum pv_context_result show_track_info(const struct playlist_entry *curre
            PV_CONTEXT_USB : PV_CONTEXT_UNCHANGED;
 }
 
+/* Edits persist immediately: write an on-disk playlist straight back after
+ * every move/remove (no Save item, no save-on-exit prompt).  The current
+ * playlist needs nothing -- it lives in its own control file.  playlist_save()
+ * refuses an empty playlist, so removing the last track truncates the file. */
+static void viewer_autosave(void)
+{
+    if (!viewer.playlist || !playlist_modified(viewer.playlist))
+        return;
+    if (playlist_amount_ex(viewer.playlist) > 0)
+        playlist_save(viewer.playlist, viewer.playlist->filename);
+    else
+    {
+        int fd = open(viewer.playlist->filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+        if (fd >= 0)
+            close(fd);
+    }
+    playlist_set_modified(viewer.playlist, false);
+}
+
 static void close_playlist_viewer(void)
 {
     if (viewer.playlist)
     {
         if (viewer.initial_selection)
             *(viewer.initial_selection) = viewer.selected_track;
-
-        if(playlist_modified(viewer.playlist))
-        {
-            if (viewer.num_tracks && yesno_pop(ID2P(LANG_SAVE_CHANGES)))
-                save_playlist_screen(viewer.playlist);
-            else if (!viewer.num_tracks &&
-                     confirm_delete_yesno(viewer.playlist->filename,
-                                          viewer.title) == YESNO_YES)
-            {
-                remove(viewer.playlist->filename);
-                reload_directory();
-            }
-        }
         playlist_close(viewer.playlist);
     }
     viewer.is_open = false;
@@ -618,6 +615,9 @@ static enum pv_context_result delete_track(int current_track_index,
     return PV_CONTEXT_MODIFIED;
 }
 
+/* Hold-A on a track: the Trimpod context menu, titled with the track's name.
+ * Just the two edit actions -- everything else lives elsewhere (play = A,
+ * shuffle = the playlist's own menu, track info = Now Playing). */
 static enum pv_context_result context_menu(int index)
 {
     struct playlist_entry *current_track = playlist_buffer_get_track(&viewer.buffer,
@@ -625,16 +625,11 @@ static enum pv_context_result context_menu(int index)
     bool current_was_playing = (audio_status() & AUDIO_STATUS_PLAY) && /* or paused */
                                (current_track->index == viewer.current_playing_track);
 
-    MENUITEM_STRINGLIST(menu_items, ID2P(LANG_PLAYLIST), NULL,
-                        ID2P(LANG_PLAYING_NEXT), ID2P(LANG_ADD_TO_PL),
-                        ID2P(LANG_REMOVE), ID2P(LANG_MOVE),
-                        ID2P(LANG_MENU_SHOW_ID3_INFO),
-                        ID2P(LANG_SHUFFLE), ID2P(LANG_SAVE)
-                        );
-    int sel = do_menu(&menu_items, NULL, NULL, false);
-    if (sel == MENU_ATTACHED_USB)
-        return PV_CONTEXT_USB;
-    else if (sel >= 0)
+    char name[MAX_PATH];
+    format_name(name, current_track->name, sizeof(name));
+    static const char *const opts[] = { "Remove from Playlist", "Move" };
+    int sel = trimpod_context_menu(name, opts, 2);
+    if (sel >= 0)
     {
         /* Abort current move */
         viewer.moving_track = -1;
@@ -643,34 +638,12 @@ static enum pv_context_result context_menu(int index)
         switch (sel)
         {
             case 0:
-                /* Playing Next... menu */
-                onplay_show_playlist_menu(current_track->name, FILE_ATTR_AUDIO, NULL);
-                return PV_CONTEXT_UNCHANGED;
-            case 1:
-                /* Add to Playlist... menu */
-                onplay_show_playlist_cat_menu(current_track->name, FILE_ATTR_AUDIO, NULL);
-                return PV_CONTEXT_UNCHANGED;
-            case 2:
                 return delete_track(current_track->index, index, current_was_playing);
-            case 3:
-                /* move track */
+            case 1:
+                /* move track: A on the destination row drops it */
                 viewer.moving_track = index;
                 viewer.moving_playlist_index = current_track->index;
                 return PV_CONTEXT_UNCHANGED;
-            case 4:
-                return show_track_info(current_track);
-            case 5:
-                /* shuffle */
-                if (!yesno_pop_confirm(ID2P(LANG_SHUFFLE)))
-                    return PV_CONTEXT_UNCHANGED;
-                playlist_sort(viewer.playlist, !viewer.playlist);
-                playlist_randomise(viewer.playlist, current_tick, !viewer.playlist);
-                viewer.selected_track = 0;
-                return PV_CONTEXT_MODIFIED;
-            case 6:
-                save_playlist_screen(viewer.playlist);
-                /* playlist indices of current playlist may have changed */
-                return viewer.playlist ? PV_CONTEXT_UNCHANGED : PV_CONTEXT_PL_UPDATE;
         }
     }
     return PV_CONTEXT_UNCHANGED;
@@ -733,10 +706,10 @@ static bool update_viewer(struct gui_synclist *playlist_lists, enum pv_context_r
 {
     bool exit = false;
     if (res == PV_CONTEXT_MODIFIED)
-        playlist_set_modified(viewer.playlist, true);
-
-    if (res == PV_CONTEXT_MODIFIED || res == PV_CONTEXT_PL_UPDATE)
     {
+        playlist_set_modified(viewer.playlist, true);
+        viewer_autosave();
+
         update_playlist(true);
         if (viewer.num_tracks <= 0)
             exit = true;
@@ -750,8 +723,9 @@ static bool update_viewer(struct gui_synclist *playlist_lists, enum pv_context_r
 
 static bool open_playlist_viewer(const char* filename,
                                   struct gui_synclist *playlist_lists,
-                                  bool reload, int *recent_selection)
+                                  int *recent_selection)
 {
+    static char title[MAX_PATH];     /* the header keeps pointing at this */
     const char *dir = NULL, *file = NULL;
     char *sep = NULL;
     viewer.loading_tick = current_tick + HZ/3;
@@ -772,7 +746,12 @@ static bool open_playlist_viewer(const char* filename,
             dir = "/";
             file = filename + 1;
         }
-        viewer.title = file;
+        /* the playlist's display name -- extension stripped, like the list */
+        strlcpy(title, file, sizeof(title));
+        char *dot = strrchr(title, '.');
+        if (dot && (!strcasecmp(dot, ".m3u8") || !strcasecmp(dot, ".m3u")))
+            *dot = '\0';
+        viewer.title = title;
     }
     else
         viewer.title = (char *) str(LANG_PLAYLIST);
@@ -792,7 +771,7 @@ static bool open_playlist_viewer(const char* filename,
     else
         push_current_activity(ACTIVITY_PLAYLISTVIEWER);
 
-    viewer.is_open = playlist_viewer_init(&viewer, dir, file, reload, recent_selection);
+    viewer.is_open = playlist_viewer_init(&viewer, dir, file, recent_selection);
 
     /* Merge separated dir and filename again */
     if (sep)
@@ -815,7 +794,7 @@ static bool s_pv_open_ok;
 static void pv_open_render(void *ctx)
 {
     struct pv_open_ctx *o = (struct pv_open_ctx *)ctx;
-    s_pv_open_ok = open_playlist_viewer(o->filename, o->lists, false, o->recent);
+    s_pv_open_ok = open_playlist_viewer(o->filename, o->lists, o->recent);
 }
 
 /* Main viewer function.  Filename identifies playlist to be viewed.  If NULL,
@@ -936,6 +915,7 @@ enum playlist_viewer_result playlist_viewer_ex(const char* filename,
                     }
 
                     playlist_set_modified(viewer.playlist, true);
+                    viewer_autosave();
 
                     update_playlist(true);
                     viewer.moving_track = -1;
@@ -973,34 +953,13 @@ enum playlist_viewer_result playlist_viewer_ex(const char* filename,
                 break;
             }
             case ACTION_STD_CONTEXT:
-            {
-                int pv_context_result = context_menu(viewer.selected_track);
-
-                if (pv_context_result == PV_CONTEXT_USB)
-                {
-                    ret = PLAYLIST_VIEWER_USB;
-                    goto exit;
-                }
-                else if (pv_context_result == PV_CONTEXT_USB_CLOSED)
-                    return PLAYLIST_VIEWER_USB;
-                else if (pv_context_result == PV_CONTEXT_WPS_CLOSED)
-                    return PLAYLIST_VIEWER_OK;
-                else if (pv_context_result == PV_CONTEXT_CLOSED)
-                {
-                    if (!open_playlist_viewer(filename, &playlist_lists, true, NULL))
-                    {
-                        ret = PLAYLIST_VIEWER_CANCEL;
-                        goto exit;
-                    }
-                    break;
-                }
-                if (update_viewer(&playlist_lists, pv_context_result))
+                if (update_viewer(&playlist_lists,
+                                  context_menu(viewer.selected_track)))
                 {
                     exit = true;
                     ret = PLAYLIST_VIEWER_CANCEL;
                 }
                 break;
-            }
             case ACTION_STD_MENU:
                 ret = PLAYLIST_VIEWER_MAINMENU;
                 goto exit;
@@ -1087,7 +1046,7 @@ bool search_playlist(void)
     struct gui_synclist playlist_lists;
     struct playlist_track_info track;
 
-    if (!playlist_viewer_init(&viewer, NULL, NULL, false, NULL))
+    if (!playlist_viewer_init(&viewer, NULL, NULL, NULL))
         return ret;
     if (kbd_input(search_str, sizeof(search_str), NULL) < 0)
         return ret;

--- a/apps/playlist_viewer.c
+++ b/apps/playlist_viewer.c
@@ -54,6 +54,7 @@
 #include "playback.h"
 #include "trimpod_transition.h"   /* slide the viewer in/out like every other screen */
 #include "trimpod_page.h"         /* trimpod_home_pending (hold-BACK -> root) */
+#include "trimpod_visualizer.h"   /* idle auto-start while music plays */
 
 
 
@@ -1034,6 +1035,10 @@ enum playlist_viewer_result playlist_viewer_ex(const char* filename,
                 break;
             }
 #endif /* HAVE_HOTKEY */
+            case ACTION_NONE:   /* idle tick */
+                if (trimpod_visualizer_maybe_autostart())
+                    gui_synclist_draw(&playlist_lists);
+                break;
             default:
                 if(default_event_handler(button) == SYS_USB_CONNECTED)
                 {

--- a/apps/root_menu.c
+++ b/apps/root_menu.c
@@ -217,6 +217,7 @@ static bool pl_owns_viewer = false;
 static int playlist_view(void * param)
 {
     (void)param;
+    char viewfile[MAX_PATH];
 
     /* A Play/Shuffle Playlist pick pending from the Playlists screen: start it
      * now and slide to Now Playing, leaving this viewer as the screen behind. */
@@ -225,6 +226,25 @@ static int playlist_view(void * param)
         case 1:  pl_owns_viewer = true;  return GO_TO_WPS;
         case -1: return GO_TO_PLAYLISTS_SCREEN;   /* empty/failed: back to the list */
         default: break;                           /* 0: nothing pending -> show it */
+    }
+
+    /* Tap A on a playlist row: show its track listing.  Picking a track there
+     * makes it the current playlist and plays from it (-> Now Playing, with
+     * the current-queue viewer behind); B backs out to the Playlists list. */
+    if (trimpod_playlists_take_pending_view(viewfile, sizeof(viewfile)))
+    {
+        switch (playlist_viewer_ex(viewfile, NULL))
+        {
+            case PLAYLIST_VIEWER_MAINMENU:
+            case PLAYLIST_VIEWER_USB:
+                pl_owns_viewer = false;
+                return GO_TO_ROOT;
+            case PLAYLIST_VIEWER_OK:        /* track picked: it's playing now */
+                pl_owns_viewer = true;
+                return GO_TO_WPS;
+            default:                        /* B: back to the Playlists list */
+                return GO_TO_PLAYLISTS_SCREEN;
+        }
     }
 
     switch (playlist_viewer())

--- a/apps/settings_list.c
+++ b/apps/settings_list.c
@@ -481,7 +481,12 @@ static void volume_limit_set_default(void* setting, void* defaultval)
 
 const struct settings_list settings[] = {
 /* system_status settings .resume.cfg */
-    SYSTEM_STATUS_SOUND(F_NO_WRAP, volume, LANG_VOLUME, "volume", SOUND_VOLUME),
+    /* Trimpod: cfg key is "volume_ddb" (deci-dB), NOT "volume".  The storage
+     * unit changed from whole dB to 0.1 dB; keeping the old key would make a
+     * pre-update .resume.cfg "volume: -30" (-30 dB) load as -3.0 dB = near max.
+     * Versioning the key makes stale old-unit values unrecognized, so volume
+     * falls back to sound_default() (-22 dB) on update instead of blasting. */
+    SYSTEM_STATUS_SOUND(F_NO_WRAP, volume, LANG_VOLUME, "volume_ddb", SOUND_VOLUME),
     SYSTEM_STATUS(0, resume_index,   -1,     "IDX"),
     SYSTEM_STATUS(0, resume_crc32,   -1,     "CRC"),
     SYSTEM_STATUS(0, resume_elapsed, -1,     "ELA"),
@@ -492,8 +497,11 @@ const struct settings_list settings[] = {
     SYSTEM_STATUS(0, last_screen,    -1,     "PVS"),
     SYSTEM_STATUS(0, last_browser,    0,     "BRS"),
 /* sound settings */
+    /* Trimpod: key versioned to "volume_limit_ddb" for the same unit change as
+     * volume_ddb above -- a stale old-unit "volume limit" is ignored (falls back
+     * to no cap) rather than misread. */
     CUSTOM_SETTING(F_NO_WRAP, volume_limit, LANG_VOLUME_LIMIT,
-                  NULL, "volume limit",
+                  NULL, "volume_limit_ddb",
                   volume_limit_load_from_cfg, volume_limit_write_to_cfg,
                   volume_limit_is_changed, volume_limit_set_default),
     SOUND_SETTING(0, balance, LANG_BALANCE, "balance", SOUND_BALANCE),
@@ -668,14 +676,14 @@ const struct settings_list settings[] = {
                 off_on, UNIT_SEC, formatter_seconds_0_is_never,
                 NULL, 10, viz_transition_values),
 #ifdef HAVE_PERCEPTUAL_VOLUME
-    /* Trimpod: perceptual by default with 20 even loudness increments (a 0..10
+    /* Trimpod: perceptual by default with 40 even loudness increments (a 0..10
      * dial); not exposed in the menu (see settings_menu.c). */
     CHOICE_SETTING(0, volume_adjust_mode, LANG_VOLUME_ADJUST_MODE,
                    VOLUME_ADJUST_PERCEPTUAL, "volume adjustment mode",
                    "direct,perceptual", NULL, 2,
                    ID2P(LANG_DIRECT), ID2P(LANG_PERCEPTUAL)),
     INT_SETTING_NOWRAP(0, volume_adjust_norm_steps, LANG_VOLUME_ADJUST_NORM_STEPS,
-                       20, "perceptual volume step count", UNIT_INT,
+                       40, "perceptual volume step count", UNIT_INT,
                        MIN_NORM_VOLUME_STEPS, MAX_NORM_VOLUME_STEPS, 5,
                        NULL, NULL),
 #endif

--- a/apps/trimpod_page.c
+++ b/apps/trimpod_page.c
@@ -21,6 +21,7 @@
 #include "trimpod_ui.h"
 #include "trimpod_page.h"
 #include "trimpod_transition.h"
+#include "trimpod_visualizer.h"   /* idle auto-start while music plays */
 
 bool trimpod_home_pending;   /* see trimpod_page.h: hold-BACK unwinds to root */
 
@@ -114,7 +115,7 @@ void trimpod_page_run(struct trimpod_page *page)
         int action = page->vt->poll ? page->vt->poll(page, HZ)
                                     : get_action(page->context, HZ);
 
-        /* Hold BACK >1s anywhere = home (the hold is timed globally in
+        /* Hold BACK anywhere = home (the hold is timed globally in
          * global_home_action).  Flag it so every enclosing loop unwinds too,
          * then leave; the dispatcher slides the Main Menu back in one step. */
         if (action == ACTION_TP_HOME)
@@ -156,6 +157,15 @@ void trimpod_page_run(struct trimpod_page *page)
          * until the exit fires.  (do_menu likewise only redraws on changes.) */
         if (shutting_down)
             continue;
+
+        /* Idle auto-start of the visualizer while music plays.  The WPS page
+         * handles this inside its own on_action (skin restore); its run stamps
+         * button activity, so it can't double-fire here. */
+        if (action == ACTION_NONE && trimpod_visualizer_maybe_autostart())
+        {
+            page_render(page);
+            continue;
+        }
 
         if (trimpod_transition_take_back())
             /* a nested page just exited: slide it out, us back in (L->R) */

--- a/apps/trimpod_page.c
+++ b/apps/trimpod_page.c
@@ -17,6 +17,7 @@
 #include "misc.h"
 #include "screens.h"          /* FOR_NB_SCREENS */
 #include "gui/viewport.h"     /* viewportmanager_theme_enable / _undo */
+#include "statusbar-skinned.h" /* sb_get_title / sb_set_title_text (%Lt) */
 #include "trimpod_ui.h"
 #include "trimpod_page.h"
 #include "trimpod_transition.h"
@@ -53,6 +54,20 @@ static void page_render_cb(void *ctx)
 void trimpod_page_run(struct trimpod_page *page)
 {
     const char *prev = trimpod_get_header_legend();
+    const char *prev_title[NB_SCREENS] = { NULL };
+    enum themable_icons prev_icon[NB_SCREENS] = { Icon_NOICON };
+
+    /* Publish the page's own header title, remembering the one underneath (the
+     * parent list's) so it is back in place before the parent redraws.  The
+     * stored icon is biased by +2 for the skin engine -- undo that on the way
+     * out and it round-trips. */
+    if (page->title)
+        FOR_NB_SCREENS(i)
+        {
+            prev_title[i] = sb_get_title(i);
+            prev_icon[i]  = (enum themable_icons)(sb_get_icon(i) - 2);
+            sb_set_title_text(page->title, Icon_NOICON, i);
+        }
 
     /* swallow the keypress that opened this page */
     action_wait_for_release();
@@ -154,6 +169,11 @@ void trimpod_page_run(struct trimpod_page *page)
     if (page->no_theme)
         FOR_NB_SCREENS(i)
             viewportmanager_theme_undo(i, false);
+
+    /* put the parent's title back */
+    if (page->title)
+        FOR_NB_SCREENS(i)
+            sb_set_title_text(prev_title[i], prev_icon[i], i);
 
     /* restore the header the parent page had, then (unless told not to) arm a
      * back slide so the screen we return to slides us away and itself back in.

--- a/apps/trimpod_page.h
+++ b/apps/trimpod_page.h
@@ -41,6 +41,11 @@ struct trimpod_page
     int        context;   /* get_action() context for the default poll */
     const int *allowed;   /* NULL = all keys; else a (-1)-terminated whitelist of
                            * allowed actions (others are swallowed) */
+    const char *title;    /* header title (%Lt) for the page's lifetime; the run
+                           * loop restores the previous one on exit.  NULL leaves
+                           * the parent's title up -- right for a page a list
+                           * already titles, wrong for one opened from a menu row
+                           * (it would keep showing the menu's name). */
 
     /* Transition behaviour.  The defaults (both false) suit a nested page that
      * is opened by a parent and returns to it: slide in forward, arm a back

--- a/apps/trimpod_playlists.c
+++ b/apps/trimpod_playlists.c
@@ -3,16 +3,16 @@
  *
  * A trimpod_page that lists the playlists in the catalog directory plus a
  * "+ Add Playlist" row, mirroring the Music Folders settings page:
- *   A on "+ Add Playlist" -> the Rockbox keyboard (catalog_pick_new_playlist_name);
- *     a confirmed name creates an empty .m3u8 and the list refreshes.
- *   A on a playlist row    -> a Play/Shuffle/Rename/Edit/Delete action chooser;
- *     Play/Shuffle start playback at once (file list sits behind Now Playing).
+ *   A on "+ Add Playlist" -> the on-screen keyboard; a confirmed name creates
+ *     an empty .m3u8 and the list refreshes.
+ *   A on a playlist row    -> its track listing (the playlist viewer); A on a
+ *     track there starts playback from it.
+ *   Hold A on a playlist   -> a Play/Shuffle/Rename/Edit/Delete context menu;
+ *     Play/Shuffle start playback at once (track list sits behind Now Playing).
  *   B                      -> leave, back to the main menu.
  *
- * NOTE: this first cut exists mainly to surface the stock Rockbox keyboard from
- * an "Add Playlist" action so its suitability can be evaluated.  The run loop,
- * header and key whitelist are owned by trimpod_page_run; this page only
- * describes the list and what A/B do.
+ * The run loop, header and key whitelist are owned by trimpod_page_run; this
+ * page only describes the list and what A/B/Hold-A do.
  ****************************************************************************/
 #include "config.h"
 #include <stdbool.h>
@@ -29,7 +29,6 @@
 #include "splash.h"
 #include "action.h"
 #include "gui/list.h"
-#include "menu.h"          /* do_menu, MENUITEM_STRINGLIST (Play/Edit/Delete) */
 #include "icon.h"
 #include "misc.h"        /* push/pop_current_activity, ACTIVITY_PLAYLISTBROWSER */
 #include "root_menu.h"
@@ -39,6 +38,7 @@
 #include "kernel.h"            /* current_tick (shuffle seed) */
 #include "scratch_buf.h"       /* scratch_buffer_get -- playlist_load buffers */
 #include "trimpod_page.h"
+#include "trimpod_transition.h"  /* arm the back slide on the B-exit only */
 #include "trimpod_ui.h"        /* trimpod_confirm */
 #include "trimpod_keyboard.h"  /* the on-screen keyboard */
 #include "trimpod_playlists.h"
@@ -58,19 +58,59 @@ static int  pl_count;
 static char pl_last_sel[MAX_PATH];
 static bool pl_have_last;
 
-/* A pending "Play Playlist" / "Shuffle Playlist" request handed to the root
- * dispatch: the action menu records the pick and returns GO_TO_PLAYLIST_VIEWER,
- * then playlist_view() calls trimpod_playlists_start_pending() to begin playback
- * so the file list sits *behind* Now Playing (backing out of the WPS reveals
- * it).  Filename only -- the catalog dir is the stable pl_dir. */
+/* A pending playlist request handed to the root dispatch, routed via
+ * GO_TO_PLAYLIST_VIEWER (playlist_view() in root_menu.c):
+ *   view (tap A)          -> open the playlist's track listing in the viewer
+ *     (trimpod_playlists_take_pending_view);
+ *   play/shuffle (Hold A) -> trimpod_playlists_start_pending() begins playback
+ *     so the track list sits *behind* Now Playing (backing out of the WPS
+ *     reveals it).  Filename only -- the catalog dir is the stable pl_dir. */
 static char pl_pending_file[MAX_PATH];
 static bool pl_pending_active;
 static bool pl_pending_shuffle;
+static bool pl_pending_view;
 
 static bool is_playlist(const char *name)
 {
     const char *dot = strrchr(name, '.');
     return dot && (!strcasecmp(dot, ".m3u") || !strcasecmp(dot, ".m3u8"));
+}
+
+/* True if the playlist file at `path` lists no tracks: empty, comments-only
+ * ('#' lines), or unreadable.  Tolerates a leading UTF-8 BOM. */
+static bool pl_file_is_empty(const char *path)
+{
+    int fd = open(path, O_RDONLY);
+    if (fd < 0)
+        return true;
+
+    static const char bom[] = "\xef\xbb\xbf";
+    char buf[512];
+    ssize_t n;
+    int pos = 0;
+    bool line_start = true, empty = true;
+    while (empty && (n = read(fd, buf, sizeof(buf))) > 0)
+    {
+        for (ssize_t i = 0; i < n; i++, pos++)
+        {
+            char c = buf[i];
+            if (pos < 3 && c == bom[pos])
+                continue;
+            if (c == '\n' || c == '\r')
+                line_start = true;
+            else if (line_start && c != ' ' && c != '\t')
+            {
+                if (c != '#')
+                {
+                    empty = false;
+                    break;
+                }
+                line_start = false;         /* comment line: skip to EOL */
+            }
+        }
+    }
+    close(fd);
+    return empty;
 }
 
 /* qsort comparator: natural alphabetical order of the names at two offsets */
@@ -313,25 +353,34 @@ static void edit_playlist(int sel)
     pop_current_activity();
 
     if (p.dirty)
-        playlist_save(p.pl, p.path);
+    {
+        if (playlist_amount_ex(p.pl) > 0)
+            playlist_save(p.pl, p.path);
+        else
+        {   /* emptied: playlist_save refuses 0 tracks -- truncate instead */
+            int fd = open(p.path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+            if (fd >= 0)
+                close(fd);
+        }
+    }
     playlist_close(p.pl);
 }
 
-/* The per-playlist action chooser.  do_menu returns the row index
- * (0 Play, 1 Rename, 2 Edit, 3 Delete) or GO_TO_PREVIOUS on cancel. */
+/* The per-playlist Hold-A context menu, titled with the playlist's name.
+ * trimpod_context_menu returns the row index or -1 on cancel. */
 enum { PL_ACT_PLAY = 0, PL_ACT_SHUFFLE, PL_ACT_RENAME, PL_ACT_EDIT, PL_ACT_DELETE };
-MENUITEM_STRINGLIST(playlist_action_menu, ID2P(LANG_PLAYLISTS), NULL,
-                    "Play Playlist", "Shuffle Playlist", "Rename Playlist",
-                    "Edit Playlist", "Delete Playlist");
+static const char *const playlist_action_opts[] =
+    { "Play", "Shuffle", "Rename", "Edit", "Delete" };
 
-/* Open the action chooser for playlist `sel`; returns TRIMPOD_PAGE_DONE when a
+/* Open the context menu for playlist `sel`; returns TRIMPOD_PAGE_DONE when a
  * chosen action leaves the page (play -> Now Playing), else STAY. */
 static enum trimpod_page_result playlist_action(struct playlists_page *p, int sel)
 {
-    char path[MAX_PATH];
+    char path[MAX_PATH], name[MAX_PATH];
     path_append(path, pl_dir, pl_namebuf + pl_off[sel], sizeof(path));
+    pl_display_name(sel, name, sizeof(name));
 
-    int act = do_menu(&playlist_action_menu, NULL, NULL, false);
+    int act = trimpod_context_menu(name, playlist_action_opts, 5);
     switch (act)
     {
         case PL_ACT_PLAY:
@@ -354,8 +403,6 @@ static enum trimpod_page_result playlist_action(struct playlists_page *p, int se
         {
             /* Pre-fill the keyboard with the current name, then rename the
              * .m3u8 file -- the same operation fileop.c's rename_file does. */
-            char name[MAX_PATH];
-            pl_display_name(sel, name, sizeof(name));
             if (trimpod_kbd_input(name, sizeof(name)) == 0 && name[0])
             {
                 char newpath[MAX_PATH];
@@ -379,8 +426,6 @@ static enum trimpod_page_result playlist_action(struct playlists_page *p, int se
             break;
         case PL_ACT_DELETE:
         {
-            char name[MAX_PATH];
-            pl_display_name(sel, name, sizeof(name));
             if (trimpod_confirm("Delete this playlist?", name))
             {
                 remove(path);
@@ -391,7 +436,7 @@ static enum trimpod_page_result playlist_action(struct playlists_page *p, int se
             }
             break;
         }
-        default:                                /* GO_TO_PREVIOUS / cancel */
+        default:                                /* -1: cancelled */
             break;
     }
     return TRIMPOD_PAGE_STAY;
@@ -437,6 +482,7 @@ static enum trimpod_page_result playlists_on_action(struct trimpod_page *self,
     if (action == ACTION_STD_CANCEL)            /* B: leave */
     {
         pl_save_pos(p, sel);
+        trimpod_transition_arm_back();          /* returning to the parent */
         return TRIMPOD_PAGE_DONE;
     }
 
@@ -447,12 +493,44 @@ static enum trimpod_page_result playlists_on_action(struct trimpod_page *self,
                                                  * pick-mode user can now select it */
         else if (sel >= 0 && sel < pl_count)    /* a playlist row */
         {
-            enum trimpod_page_result r =
-                p->pick ? pick_into_existing(p, sel) : playlist_action(p, sel);
-            if (r == TRIMPOD_PAGE_DONE)          /* leaving (e.g. play -> WPS) */
-                pl_save_pos(p, sel);
-            return r;
+            if (p->pick)
+            {
+                enum trimpod_page_result r = pick_into_existing(p, sel);
+                if (r == TRIMPOD_PAGE_DONE)
+                    pl_save_pos(p, sel);
+                return r;
+            }
+            /* tap A: open this playlist's track listing (playlist_view()
+             * consumes the pending view and runs the viewer on it).  The
+             * viewer refuses an empty playlist, so teach the add gesture
+             * instead of bouncing. */
+            char path[MAX_PATH];
+            path_append(path, pl_dir, pl_namebuf + pl_off[sel], sizeof(path));
+            if (pl_file_is_empty(path))
+            {
+                char name[MAX_PATH];
+                pl_display_name(sel, name, sizeof(name));
+                static const char *const rows[] =
+                    { "Playlist is empty", "Hold A on any song",
+                      "to add it to a playlist" };
+                trimpod_message_page(name, rows, 3);
+                return TRIMPOD_PAGE_STAY;
+            }
+            strlcpy(pl_pending_file, pl_namebuf + pl_off[sel],
+                    sizeof pl_pending_file);
+            pl_pending_view = true;
+            p->result = GO_TO_PLAYLIST_VIEWER;
+            pl_save_pos(p, sel);
+            return TRIMPOD_PAGE_DONE;
         }
+    }
+    else if (action == ACTION_STD_CONTEXT       /* Hold A: playlist actions */
+             && !p->pick && sel >= 0 && sel < pl_count)
+    {
+        enum trimpod_page_result r = playlist_action(p, sel);
+        if (r == TRIMPOD_PAGE_DONE)              /* leaving (play -> WPS) */
+            pl_save_pos(p, sel);
+        return r;
     }
     return TRIMPOD_PAGE_STAY;                    /* the runner redraws each frame */
 }
@@ -465,8 +543,10 @@ static const struct trimpod_page_vtable playlists_vtable =
     .on_action = playlists_on_action,
 };
 
-/* only A (add/open) and B (back) act; list scrolling is consumed in poll */
-static const int playlists_allowed[] = { ACTION_STD_OK, ACTION_STD_CANCEL, -1 };
+/* A (open/add), Hold-A (playlist actions) and B (back) act; list scrolling is
+ * consumed in poll */
+static const int playlists_allowed[] = { ACTION_STD_OK, ACTION_STD_CONTEXT,
+                                         ACTION_STD_CANCEL, -1 };
 
 /* Shared driver: (re)read the catalog, run the page with the given title. */
 static int run_playlists(struct playlists_page *p, const char *title)
@@ -507,6 +587,18 @@ static int run_playlists(struct playlists_page *p, const char *title)
  * shuffle is left untouched.  Returns 1 when playback started (caller -> Now
  * Playing), 0 when nothing was pending (caller -> show the file list), or -1 on
  * an empty/unloadable playlist (caller -> back to the Playlists list). */
+/* Consume a pending view request (tap A on a playlist row): fill `path` with
+ * the playlist's full path and return true.  playlist_view() then opens the
+ * stock viewer on it -- A on a track there starts playback from that track. */
+bool trimpod_playlists_take_pending_view(char *path, size_t len)
+{
+    if (!pl_pending_view)
+        return false;
+    pl_pending_view = false;
+    path_append(path, pl_dir, pl_pending_file, len);
+    return true;
+}
+
 int trimpod_playlists_start_pending(void)
 {
     if (!pl_pending_active)
@@ -532,10 +624,13 @@ int trimpod_playlists_screen(void *param)
     (void)param;
     struct playlists_page p =
     {
-        /* enter_honor_back: returning from Now Playing (which armed a back)
-         * slides this screen in L->R; a fresh open from the root enters forward. */
+        /* enter_honor_back: returning from the viewer / Now Playing (which
+         * armed a back) slides this screen in L->R; a fresh open from the root
+         * enters forward.  no_arm_back: the exit slide is armed explicitly
+         * (only on B), so tap-A slides forward into the track listing. */
         .base = { .vt = &playlists_vtable, .context = CONTEXT_LIST,
-                  .allowed = playlists_allowed, .enter_honor_back = true },
+                  .allowed = playlists_allowed, .enter_honor_back = true,
+                  .no_arm_back = true },
         /* Back to the root menu via GO_TO_ROOT (NOT GO_TO_PREVIOUS): the root
          * dispatch keeps last_screen == our entry, so the menu re-highlights the
          * "Playlists" row on return -- the same contract Settings uses. */

--- a/apps/trimpod_playlists.h
+++ b/apps/trimpod_playlists.h
@@ -4,6 +4,9 @@
 #ifndef _TRIMPOD_PLAYLISTS_H
 #define _TRIMPOD_PLAYLISTS_H
 
+#include <stdbool.h>
+#include <stddef.h>
+
 /* root menu Playlists entry (a root_menu items[] function) */
 int trimpod_playlists_screen(void *param);
 
@@ -12,6 +15,11 @@ int trimpod_playlists_screen(void *param);
  * or -1 (empty/failed -> back to the list).  Called by root_menu.c's
  * playlist_view() so the file list ends up behind Now Playing. */
 int trimpod_playlists_start_pending(void);
+
+/* Consume a pending view request (tap A on a playlist row): fill `path` with
+ * the playlist's full .m3u8 path and return true.  Called by playlist_view()
+ * to open the playlist's track listing in the stock viewer. */
+bool trimpod_playlists_take_pending_view(char *path, size_t len);
 
 /* Show the Playlists screen in "pick" mode: the chosen (or newly created)
  * playlist receives `sel` (a file or directory) via the stock Rockbox

--- a/apps/trimpod_ui.c
+++ b/apps/trimpod_ui.c
@@ -259,7 +259,7 @@ struct about_line { const char *text; enum about_kind kind; };
 
 static const struct about_line about_lines[] = {
     { "Trimpod Classic",     AB_TITLE },
-    { "v1.0.2",              AB_SUB   },
+    { "v1.0.3",              AB_SUB   },
     { NULL,                  AB_GAP   },
     { "MADE BY",             AB_CAP   },
     { "Werewolf Camp",       AB_NAME  },

--- a/apps/trimpod_ui.c
+++ b/apps/trimpod_ui.c
@@ -507,21 +507,21 @@ void trimpod_about(void)
         font_unload(fid);
 }
 
-/* ---- Controls: a static reference card for the four inputs.  Same chrome as
- * every other page; the body is a left-aligned list, the block itself centred
- * on the widest row.  B leaves. --------------------------------------------- */
+/* ---- Message page: a static block of text rows.  Same chrome as every other
+ * page (title header + slide); the body is a left-aligned list, the block
+ * itself centred on the widest row.  B leaves.  The Controls reference card
+ * and the empty-playlist hint are both this page with different rows. ------- */
 
-static const char *const controls_rows[] = {
-    "B - Back/Cancel",
-    "A - Play/Enter",
-    "Hold A - Context Menus",
-    "Side Switch - Lock Buttons",
-};
-#define CONTROLS_NROWS ((int)(sizeof(controls_rows) / sizeof(controls_rows[0])))
-
-static void controls_draw(struct trimpod_page *self)
+struct message_page
 {
-    (void)self;
+    struct trimpod_page base;
+    const char *const *rows;
+    int nrows;
+};
+
+static void message_draw(struct trimpod_page *self)
+{
+    struct message_page *p = (struct message_page *)self;
     struct screen *s = &screens[SCREEN_MAIN];
     struct viewport vp = {0};
 
@@ -530,49 +530,67 @@ static void controls_draw(struct trimpod_page *self)
     s->clear_viewport();
 
     int w, fh = 0, block = 0;
-    for (int i = 0; i < CONTROLS_NROWS; i++)
+    for (int i = 0; i < p->nrows; i++)
     {
-        s->getstringsize((const unsigned char *)controls_rows[i], &w, &fh);
+        s->getstringsize((const unsigned char *)p->rows[i], &w, &fh);
         if (w > block) block = w;                 /* the widest row sets the left edge */
     }
 
     const int line = fh + 8;
     int x = (vp.width - block) / 2;
-    int y = (vp.height - CONTROLS_NROWS * line) / 2;
+    int y = (vp.height - p->nrows * line) / 2;
     if (x < 0) x = 0;
     if (y < 0) y = 0;
 
-    for (int i = 0; i < CONTROLS_NROWS; i++, y += line)
-        s->putsxy(x, y, (const unsigned char *)controls_rows[i]);
+    for (int i = 0; i < p->nrows; i++, y += line)
+        s->putsxy(x, y, (const unsigned char *)p->rows[i]);
 
     s->update_viewport();
     s->set_viewport(NULL);
 }
 
-static enum trimpod_page_result controls_on_action(struct trimpod_page *self,
-                                                   int action)
+static enum trimpod_page_result message_on_action(struct trimpod_page *self,
+                                                  int action)
 {
     (void)self;
     return (action == ACTION_STD_CANCEL) ? TRIMPOD_PAGE_DONE : TRIMPOD_PAGE_STAY;
 }
 
-static const struct trimpod_page_vtable controls_vtable =
+static const struct trimpod_page_vtable message_vtable =
 {
     .legend    = NULL,            /* just the title, no status-bar legend */
-    .draw      = controls_draw,
+    .draw      = message_draw,
     .poll      = NULL,            /* default: get_action(CONTEXT_STD) */
-    .on_action = controls_on_action,
+    .on_action = message_on_action,
 };
 
 /* only B leaves */
-static const int controls_allowed[] = { ACTION_STD_CANCEL, -1 };
+static const int message_allowed[] = { ACTION_STD_CANCEL, -1 };
+
+void trimpod_message_page(const char *title, const char *const *rows, int nrows)
+{
+    struct message_page p =
+    {
+        .base = { .vt = &message_vtable, .context = CONTEXT_STD,
+                  .allowed = message_allowed, .title = title },
+        .rows = rows, .nrows = nrows,
+    };
+    trimpod_page_run(&p.base);
+}
+
+/* Controls: a static reference card for the four inputs. */
+static const char *const controls_rows[] = {
+    "B - Back/Cancel",
+    "A - Play/Enter",
+    "Hold A - Context Menus",
+    "Side Switch - Lock Buttons",
+};
+#define CONTROLS_NROWS ((int)(sizeof(controls_rows) / sizeof(controls_rows[0])))
 
 void trimpod_controls(void)
 {
-    struct trimpod_page p = { .vt = &controls_vtable, .context = CONTEXT_STD,
-                              .allowed = controls_allowed,
-                              .title = (const char *)str(LANG_TRIMPOD_CONTROLS) };
-    trimpod_page_run(&p);
+    trimpod_message_page((const char *)str(LANG_TRIMPOD_CONTROLS),
+                         controls_rows, CONTROLS_NROWS);
 }
 
 /* Measure every reel line once to fault its glyphs into the cache now (startup),

--- a/apps/trimpod_ui.c
+++ b/apps/trimpod_ui.c
@@ -21,6 +21,7 @@
 #include "kernel.h"
 #include "system.h"
 #include "action.h"
+#include "lang.h"                /* str(): the page titles are localised */
 #include "screens.h"
 #include "lcd.h"
 #include "font.h"
@@ -485,6 +486,7 @@ void trimpod_about(void)
     {
         .base = { .vt = &about_vtable, .context = CONTEXT_STD,
                   .allowed = about_allowed,
+                  .title = (const char *)str(LANG_TRIMPOD_ABOUT),
                   .animated = true, .no_header_refresh = true },
         .start_tick  = current_tick,
         .header_done = false,
@@ -503,6 +505,74 @@ void trimpod_about(void)
     s->setfont(FONT_UI);
     if (fid != FONT_UI)
         font_unload(fid);
+}
+
+/* ---- Controls: a static reference card for the four inputs.  Same chrome as
+ * every other page; the body is a left-aligned list, the block itself centred
+ * on the widest row.  B leaves. --------------------------------------------- */
+
+static const char *const controls_rows[] = {
+    "B - Back/Cancel",
+    "A - Play/Enter",
+    "Hold A - Context Menus",
+    "Side Switch - Lock Buttons",
+};
+#define CONTROLS_NROWS ((int)(sizeof(controls_rows) / sizeof(controls_rows[0])))
+
+static void controls_draw(struct trimpod_page *self)
+{
+    (void)self;
+    struct screen *s = &screens[SCREEN_MAIN];
+    struct viewport vp = {0};
+
+    viewport_set_defaults(&vp, s->screen_type);   /* content area, not header */
+    s->set_viewport(&vp);
+    s->clear_viewport();
+
+    int w, fh = 0, block = 0;
+    for (int i = 0; i < CONTROLS_NROWS; i++)
+    {
+        s->getstringsize((const unsigned char *)controls_rows[i], &w, &fh);
+        if (w > block) block = w;                 /* the widest row sets the left edge */
+    }
+
+    const int line = fh + 8;
+    int x = (vp.width - block) / 2;
+    int y = (vp.height - CONTROLS_NROWS * line) / 2;
+    if (x < 0) x = 0;
+    if (y < 0) y = 0;
+
+    for (int i = 0; i < CONTROLS_NROWS; i++, y += line)
+        s->putsxy(x, y, (const unsigned char *)controls_rows[i]);
+
+    s->update_viewport();
+    s->set_viewport(NULL);
+}
+
+static enum trimpod_page_result controls_on_action(struct trimpod_page *self,
+                                                   int action)
+{
+    (void)self;
+    return (action == ACTION_STD_CANCEL) ? TRIMPOD_PAGE_DONE : TRIMPOD_PAGE_STAY;
+}
+
+static const struct trimpod_page_vtable controls_vtable =
+{
+    .legend    = NULL,            /* just the title, no status-bar legend */
+    .draw      = controls_draw,
+    .poll      = NULL,            /* default: get_action(CONTEXT_STD) */
+    .on_action = controls_on_action,
+};
+
+/* only B leaves */
+static const int controls_allowed[] = { ACTION_STD_CANCEL, -1 };
+
+void trimpod_controls(void)
+{
+    struct trimpod_page p = { .vt = &controls_vtable, .context = CONTEXT_STD,
+                              .allowed = controls_allowed,
+                              .title = (const char *)str(LANG_TRIMPOD_CONTROLS) };
+    trimpod_page_run(&p);
 }
 
 /* Measure every reel line once to fault its glyphs into the cache now (startup),

--- a/apps/trimpod_ui.h
+++ b/apps/trimpod_ui.h
@@ -38,13 +38,16 @@ bool trimpod_confirm(const char *question, const char *detail);
  * chosen row index, or -1 if the user backed out with B.  Blocking. */
 int trimpod_context_menu(const char *title, const char *const *items, int count);
 
-/* The About screen: a scrollable credits list (up/down scroll, B leaves).
+/* The About screen: a credits reel that drifts up and down on its own (B leaves).
  * Blocking. */
 void trimpod_about(void);
 
 /* Pre-fault the About reel's glyphs into the font cache at startup, so the first
  * (possibly mid-playback) About open doesn't stall the codec on disk reads. */
 void trimpod_about_prewarm(void);
+
+/* The Controls screen: a static list of the app's inputs (B leaves).  Blocking. */
+void trimpod_controls(void);
 
 /* The shared on/off toggle glyph ("[x]"/"[ ]") for list indicator callbacks.
  * One convention for every toggle list (Menu Settings, Visualizers, ...). */

--- a/apps/trimpod_ui.h
+++ b/apps/trimpod_ui.h
@@ -46,6 +46,10 @@ void trimpod_about(void);
  * (possibly mid-playback) About open doesn't stall the codec on disk reads. */
 void trimpod_about_prewarm(void);
 
+/* A static text page: `rows` rendered as a centred block under a `title`
+ * header (B leaves).  Blocking. */
+void trimpod_message_page(const char *title, const char *const *rows, int nrows);
+
 /* The Controls screen: a static list of the app's inputs (B leaves).  Blocking. */
 void trimpod_controls(void);
 

--- a/apps/trimpod_visualizer.c
+++ b/apps/trimpod_visualizer.c
@@ -44,6 +44,7 @@
 #include "string-extra.h"       /* strlcpy */
 #include "strnatcmp.h"          /* natural alphabetical sort of the preset list */
 #include "action.h"
+#include "audio.h"             /* audio_status: gate the idle auto-start on playback */
 #include "lcd.h"
 #include "backlight.h"         /* backlight_set_timeout: suspend Auto Screen Off while visualizing */
 #include "kernel.h"
@@ -509,6 +510,8 @@ static void visualizer_session(const char *locked_path)
     {
         trimpod_viz_active = false;   /* the entry fade may have set it */
         viz_entry_faded = false;
+        /* undo the entry fade's Auto-Screen-Off freeze (no-op without a fade) */
+        backlight_set_timeout(global_settings.backlight_timeout);
         lcd_update();                 /* hand the window back, restore the screen */
         return;
     }
@@ -598,6 +601,10 @@ void trimpod_visualizer_run(void)
  * the visualizer (loaded while black) fades in from black. */
 bool trimpod_visualizer_fade_to_black(void)
 {
+    /* Freeze Auto Screen Off so it can't blank mid-fade/mid-load;
+     * visualizer_session keeps it suspended and restores it on exit (the
+     * cancel path below restores it directly). */
+    backlight_set_timeout(0);
     sdl_gl_make_current();
     SDL_GL_SetSwapInterval(1);   /* vsync-pace the fade so it's smooth (else the
                                   * first fade, before viz_gl_init, runs un-paced) */
@@ -614,9 +621,14 @@ bool trimpod_visualizer_fade_to_black(void)
         sdl_gl_present_lcd_fade(fade);
 
         int act = get_action(CONTEXT_STD, TIMEOUT_NOBLOCK);
-        if (act != ACTION_NONE && act != ACTION_REDRAW)   /* real button -> cancel */
+        bool blanked = power_display_off();  /* power short press mid-fade */
+        if (blanked || (act != ACTION_NONE && act != ACTION_REDRAW))
         {
-            sdl_gl_present_lcd_fade(1.0f);   /* snap Now Playing back to full */
+            if (blanked)   /* stay dark: restore without waking the panel */
+                backlight_set_timeout_quiet(global_settings.backlight_timeout);
+            else
+                backlight_set_timeout(global_settings.backlight_timeout);
+            sdl_gl_present_lcd_fade(1.0f);   /* snap the screen back to full */
             trimpod_viz_active = false;      /* hand the window back to the LCD */
             return true;                     /* cancelled */
         }
@@ -627,6 +639,28 @@ bool trimpod_visualizer_fade_to_black(void)
     viz_entry_faded = true;   /* visualizer_session keeps trimpod_viz_active set,
                                * then fades IN from black */
     return false;
+}
+
+bool trimpod_visualizer_autostart_due(void)
+{
+    int status = audio_status();
+    return global_settings.viz_start_delay > 0
+        && !power_display_off()   /* suspended while display blanked */
+        && is_backlight_on(true)  /* screen dark from Auto Screen Off: stay
+                                   * dark (Never counts as always-on) */
+        && (status & AUDIO_STATUS_PLAY)
+        && !(status & AUDIO_STATUS_PAUSE)
+        && TIME_AFTER(current_tick, button_last_activity_tick()
+                      + global_settings.viz_start_delay * HZ);
+}
+
+bool trimpod_visualizer_maybe_autostart(void)
+{
+    if (!trimpod_visualizer_autostart_due())
+        return false;
+    if (!trimpod_visualizer_fade_to_black())   /* fade completed -> launch */
+        trimpod_visualizer_run();
+    return true;   /* screen disturbed either way: caller repaints */
 }
 
 /* ---- Settings -> Visualizers: the on/off toggle list -----------------------

--- a/apps/trimpod_visualizer.h
+++ b/apps/trimpod_visualizer.h
@@ -6,8 +6,9 @@
  *   Firmware   |____|_  /\____/ \___  >__|_ \|___  /\____/__/\_ \
  *                     \/            \/     \/    \/            \/
  *
- * Trimpod: Milkdrop-style music visualizer (projectM), shown from the Now
- * Playing screen. See apps/trimpod_visualizer.c.
+ * Trimpod: Milkdrop-style music visualizer (projectM), started from the Now
+ * Playing menu or auto-started after idle while music plays (any screen).
+ * See apps/trimpod_visualizer.c.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -31,6 +32,16 @@ void trimpod_visualizer_run(void);
  * loaded visualizer fades up from black -- hides the load.  Returns true if a
  * keypress cancelled the fade (caller should NOT launch the visualizer). */
 bool trimpod_visualizer_fade_to_black(void);
+
+/* True when the idle auto-start timer has expired: a delay is configured, the
+ * display is on, and music is actively playing (not paused). */
+bool trimpod_visualizer_autostart_due(void);
+
+/* Idle auto-start for a UI loop's timeout path: when due, fade to black and
+ * run the visualizer.  Returns true if the screen needs a repaint (the fade
+ * ran, cancelled or not); false = not due.  The WPS runs the sequence inline
+ * instead -- it must restore the skin around the run. */
+bool trimpod_visualizer_maybe_autostart(void);
 
 /* Settings -> Visualizers: a flat on/off toggle list of the shipped presets.
  * A toggles the highlighted preset (only enabled presets are auto-cycled on Now

--- a/assets/theme/1ST_GEN_REMIX/.rockbox/wps/1ST_GEN_REMIX.wps
+++ b/assets/theme/1ST_GEN_REMIX/.rockbox/wps/1ST_GEN_REMIX.wps
@@ -75,7 +75,7 @@
 %ar-%pr
 
 # Panel: VOLUME -- shown ~1s after a volume change (%mv).  Perceptual 0..10 dial
-# (20 even loudness steps): empty = 0 (silence), full = 10 (max), default = 5.
+# (40 even loudness steps): empty = 0 (silence), full = 10 (max), default = 5.
 # End labels are plain "0"/"10"; no dB (the scale isn't user-facing).
 %Vl(npVolume,20,190,280,14,-)%Vf(-)%Vb(-)
 %pv(0,0,-,14,PBB,backdrop,PB)

--- a/firmware/export/config.h
+++ b/firmware/export/config.h
@@ -732,7 +732,7 @@ Lyre prototype 1 */
 
 /* Trimpod: perceptual volume ON -- the rocker steps and the bar both move in
  * equal perceived-loudness increments (volume_adjust_mode=perceptual,
- * volume_adjust_norm_steps=20), so the bar reads as a plain 0..10 loudness dial
+ * volume_adjust_norm_steps=40), so the bar reads as a plain 0..10 loudness dial
  * (middle = half), not the raw logarithmic dB. The dB stays the storage unit;
  * users never see it (the volume_adjust_* knobs are hidden from the menu). */
 #define HAVE_PERCEPTUAL_VOLUME

--- a/firmware/export/lcd.h
+++ b/firmware/export/lcd.h
@@ -172,6 +172,12 @@ extern void lcd_init_device(void) INIT_ATTR;
 /* Trimpod (SDL app): drop on-screen presents while set, so a frame can be
  * rendered to the framebuffer off-screen (slide transitions). */
 extern void lcd_set_update_suppressed(bool suppress);
+
+/* Panel dark (backlight off / power blank): drawing still updates the surfaces,
+ * but presenting to the panel is skipped until it wakes.  Set from the backlight
+ * driver; the wake transition presents the current content once. */
+extern void lcd_set_panel_dark(bool dark);
+extern bool lcd_panel_is_dark(void);
 extern bool lcd_is_update_suppressed(void);
 
 extern void lcd_backlight(bool on);

--- a/firmware/export/sdl_codec.h
+++ b/firmware/export/sdl_codec.h
@@ -20,7 +20,15 @@
 #ifndef _SDL_CODEC_H
 #define _SDL_CODEC_H
 
-// This is pretty generic and probably needs adjusting
-AUDIOHW_SETTING(VOLUME,      "dB",   0,  1, -80,   0,   0)
+/* Trimpod: 0.1 dB resolution (numdecimals=1, step=1) so the perceptual notch
+ * table lands on evenly-spaced perceived-loudness steps instead of snapping to
+ * coarse whole-dB values (the old "dB",0,1 quantized every notch to 1 dB, which
+ * made the rocker steps -- and the volume bar -- visibly/audibly uneven).  Range
+ * -80.0..-3.0 dB: the -3 dB ceiling trims the top of the shipped range (nobody
+ * runs max) so the notches pack into the usable band.  Default -22.0 dB.
+ * NOTE: min/max/default are in 0.1 dB units; the storage unit changed, so any
+ * saved whole-dB "volume:" value must be migrated (x10) or reset -- see the pak
+ * config.cfg and the clean-deploy requirement. */
+AUDIOHW_SETTING(VOLUME,      "dB",   1,  1, -800, -30, -220)
 
 #endif /* _SDL_CODEC_H */

--- a/firmware/target/hosted/sdl/button-sdl.c
+++ b/firmware/target/hosted/sdl/button-sdl.c
@@ -392,6 +392,10 @@ int button_read_device(void)
                  * button (is_backlight_on() is the real state; power_blanked
                  * covers the always-on cases where it can't tell, e.g. viz).
                  * Otherwise blank it. */
+                /* The power key never reaches button_tick's stamp, so mark the
+                 * activity here -- a wake must restart the idle timers (viz
+                 * auto-start), not leave them expired. */
+                button_touch_activity();
                 if (power_blanked || !is_backlight_on(true))
                 {
                     backlight_on();

--- a/firmware/target/hosted/sdl/button-sdl.c
+++ b/firmware/target/hosted/sdl/button-sdl.c
@@ -207,7 +207,7 @@ static bool event_handler(SDL_Event *event)
         else if(event->window.event == SDL_WINDOWEVENT_RESIZED)
         {
             SDL_LockMutex(window_mutex);
-            sdl_window_adjustment_needed(false);
+            sdl_window_adjustment_needed();
             SDL_UnlockMutex(window_mutex);
             static unsigned long last_tick;
             if (TIME_AFTER(current_tick, last_tick + HZ/20) && !button_queue_full())

--- a/firmware/target/hosted/sdl/lcd-bitmap.c
+++ b/firmware/target/hosted/sdl/lcd-bitmap.c
@@ -108,6 +108,28 @@ void lcd_update(void)
     lcd_update_rect(0, 0, LCD_WIDTH, LCD_HEIGHT);
 }
 
+/* Trimpod: the panel is dark (Auto Screen Off timeout or a manual power blank).
+ * Nothing drawn can be seen, and on this target every present is a full-window
+ * 3.2x upscale + swap -- the single most expensive thing the app does.  Drawing
+ * still lands in the surfaces (so they stay current); only the push to the panel
+ * is skipped, and waking pushes once.  Driven by backlight_hw_on/off, which is
+ * where the panel physically changes state. */
+static bool lcd_panel_dark = false;
+
+void lcd_set_panel_dark(bool dark)
+{
+    if (lcd_panel_dark == dark)
+        return;
+    lcd_panel_dark = dark;
+    if (!dark)
+        lcd_update();   /* wake: present what the surfaces already hold */
+}
+
+bool lcd_panel_is_dark(void)
+{
+    return lcd_panel_dark;
+}
+
 void lcd_update_rect(int x_start, int y_start, int width, int height)
 {
     if (lcd_update_suppressed)
@@ -119,27 +141,6 @@ void lcd_update_rect(int x_start, int y_start, int width, int height)
                    background ? UI_LCD_POSX : 0, background? UI_LCD_POSY : 0);
 }
 
-#if (SDL_MAJOR_VERSION > 1)
-void sim_backlight(int value)
-{
-#if LCD_DEPTH <= 8
-    if (value > 0) {
-        sdl_set_gradient(lcd_surface, &lcd_bl_color_dark,
-                         &lcd_bl_color_bright, 0, NUM_SHADES);
-    } else {
-        sdl_set_gradient(lcd_surface, &lcd_color_dark,
-                         &lcd_color_bright, 0, NUM_SHADES);
-    }
-#else /* LCD_DEPTH > 8 */
-    SDL_SetSurfaceAlphaMod(lcd_surface, (value * 255) / 100);
-#endif /* LCD_DEPTH */
-
-    sdl_gui_update(lcd_surface, 0, 0, SIM_LCD_WIDTH, SIM_LCD_HEIGHT,
-                   SIM_LCD_WIDTH, SIM_LCD_HEIGHT,
-                   background ? UI_LCD_POSX : 0, background? UI_LCD_POSY : 0);
-}
-#endif /* SDL_MAJOR_VERSION > 1 */
-
 /* initialise simulator lcd driver */
 void lcd_init_device(void)
 {
@@ -147,7 +148,13 @@ void lcd_init_device(void)
     lcd_surface = SDL_CreateRGBSurface(SDL_SWSURFACE, SIM_LCD_WIDTH, SIM_LCD_HEIGHT,
                                        LCD_DEPTH, 0, 0, 0, 0);
 #if SDL_MAJOR_VERSION > 1
-    SDL_SetSurfaceBlendMode(lcd_surface, SDL_BLENDMODE_BLEND);
+    /* BLENDMODE_NONE, not BLEND: the surface has no alpha channel (masks are 0)
+     * and this target has a real hardware backlight, so nothing ever sets an
+     * alpha mod -- BLEND only forced every frame's copy into sim_lcd_surface
+     * through SDL's per-pixel software blender (15ms/frame vs 0.3ms for a plain
+     * copy).  Blending only ever served the simulator's fake backlight dimming,
+     * which this target does not use -- it has a real one. */
+    SDL_SetSurfaceBlendMode(lcd_surface, SDL_BLENDMODE_NONE);
 #endif
 #elif LCD_DEPTH <= 8
     lcd_surface = SDL_CreateRGBSurface(SDL_SWSURFACE, SIM_LCD_WIDTH, SIM_LCD_HEIGHT,

--- a/firmware/target/hosted/sdl/retro-handheld/backlight-target.c
+++ b/firmware/target/hosted/sdl/retro-handheld/backlight-target.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "config.h"
+#include "lcd.h"                /* lcd_set_panel_dark: stop presenting while dark */
 #include "backlight-target.h"
 #include "sysfs.h"
 #include "panic.h"
@@ -88,8 +89,13 @@ void backlight_hw_on(void)
 {
     if (last_bl != 1) {
     
+    /* Present BEFORE lighting the panel: the surfaces were kept current while
+     * dark, so the panel comes up already showing them.  Lighting first would
+     * flash the frame from when it went dark until this present landed. */
+    lcd_set_panel_dark(false);
+
     switch (get_type()) {
-        case BL_TYPE1: set_type1_brightness(15); break;        
+        case BL_TYPE1: set_type1_brightness(15); break;
         case BL_TYPE2: sysfs_set_int(get_bl_env("SYSFS_BL_POWER"), 0); break;
     }
 
@@ -102,11 +108,12 @@ void backlight_hw_off(void)
     if (last_bl != 0) {
 
     switch (get_type()) {
-        case BL_TYPE1: set_type1_brightness(0); break;        
+        case BL_TYPE1: set_type1_brightness(0); break;
         case BL_TYPE2: sysfs_set_int(get_bl_env("SYSFS_BL_POWER"), 1); break;
     }
 
 	last_bl = 0;
+    lcd_set_panel_dark(true);    /* dark: stop presenting to a panel that is off */
     }
 }
 

--- a/firmware/target/hosted/sdl/window-sdl.c
+++ b/firmware/target/hosted/sdl/window-sdl.c
@@ -22,6 +22,7 @@
 #include "window-sdl.h"
 #include "lcd-sdl.h"
 #include "misc.h"
+#include "lcd.h"        /* lcd_panel_is_dark: no presents while the panel is off */
 #include "panic.h"
 
 /* Trimpod renders through an OpenGL ES 2/3 context (not an SDL_Renderer) so the
@@ -32,16 +33,12 @@
 
 extern SDL_Surface *lcd_surface;
 
-SDL_Texture  *gui_texture;
 SDL_Surface  *sim_lcd_surface;
 
 SDL_mutex *window_mutex;
 
 SDL_Window   *sdlWindow;
-static SDL_Renderer *sdlRenderer;
-static SDL_Surface  *picture_surface;
 
-static bool new_gui_texture_needed = true;
 static bool window_adjustment_needed;
 double display_zoom = 1;
 
@@ -49,10 +46,11 @@ double display_zoom = 1;
  * suppress the normal LCD presentation so other Rockbox threads' lcd_update()
  * calls don't fight for the context. */
 volatile bool trimpod_viz_active = false;
+
 static SDL_GLContext gl_ctx = NULL;
 static GLuint gl_lcd_tex = 0, gl_prog = 0, gl_vbo = 0;
 static GLint  gl_u_fade = -1;
-static SDL_Surface *gl_conv = NULL;   /* RGBA8888 conversion of the LCD surface */
+static int gl_tex_w = 0, gl_tex_h = 0; /* size gl_lcd_tex is currently allocated for */
 
 static const char *gl_vs_src =
     "attribute vec2 a_pos;\n"
@@ -64,7 +62,10 @@ static const char *gl_fs_src =
     "varying vec2 v_uv;\n"
     "uniform sampler2D u_tex;\n"
     "uniform float u_fade;\n"   /* 1 = normal, 0 = black (visualizer entry fade) */
-    "void main(){ gl_FragColor = vec4(texture2D(u_tex, v_uv).rgb * u_fade, 1.0); }\n";
+    /* .bgr, not .rgb: the 24-bit Rockbox framebuffer stores blue first (lcd.h:
+     * fb_data is {b, g, r}) and it is uploaded verbatim as GL_RGB, so the swizzle
+     * here puts the channels back in order -- free, vs. a per-frame conversion. */
+    "void main(){ gl_FragColor = vec4(texture2D(u_tex, v_uv).bgr * u_fade, 1.0); }\n";
 
 static GLuint gl_compile(GLenum type, const char *src)
 {
@@ -106,6 +107,7 @@ static void gl_init_present(void)
     glBufferData(GL_ARRAY_BUFFER, sizeof(verts), verts, GL_STATIC_DRAW);
 
     glGenTextures(1, &gl_lcd_tex);
+    gl_tex_w = gl_tex_h = 0;   /* fresh texture: next present must allocate it */
     glBindTexture(GL_TEXTURE_2D, gl_lcd_tex);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -133,15 +135,6 @@ static void gl_present_lcd_fade(SDL_Surface *src, float fade)
 {
     int w, h;
 
-    if (!gl_conv || gl_conv->w != src->w || gl_conv->h != src->h)
-    {
-        if (gl_conv)
-            SDL_FreeSurface(gl_conv);
-        gl_conv = SDL_CreateRGBSurfaceWithFormat(0, src->w, src->h, 32,
-                                                 SDL_PIXELFORMAT_ABGR8888);
-    }
-    SDL_BlitSurface(src, NULL, gl_conv, NULL);
-
     SDL_GL_GetDrawableSize(sdlWindow, &w, &h);
     glViewport(0, 0, w, h);
     glDisable(GL_DEPTH_TEST);   /* projectM may leave these on */
@@ -153,8 +146,23 @@ static void gl_present_lcd_fade(SDL_Surface *src, float fade)
     glUniform1f(gl_u_fade, fade);
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, gl_lcd_tex);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, gl_conv->w, gl_conv->h, 0,
-                 GL_RGBA, GL_UNSIGNED_BYTE, gl_conv->pixels);
+    /* The LCD surface is 24bpp RGB888 -- byte order R,G,B, exactly what
+     * GL_RGB/GL_UNSIGNED_BYTE expects -- so it uploads verbatim: no conversion
+     * pass, and a quarter less data than RGBA.  SDL pads surface rows to 4 bytes
+     * and GL's default unpack alignment is 4, so the strides agree for any width
+     * (the alignment is left alone -- it is global state projectM shares).
+     * Re-specifying the texture every frame made the driver reallocate it; only
+     * a size change needs that, otherwise update in place. */
+    if (src->w != gl_tex_w || src->h != gl_tex_h)
+    {
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, src->w, src->h, 0,
+                     GL_RGB, GL_UNSIGNED_BYTE, src->pixels);
+        gl_tex_w = src->w;
+        gl_tex_h = src->h;
+    }
+    else
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, src->w, src->h,
+                        GL_RGB, GL_UNSIGNED_BYTE, src->pixels);
 
     glBindBuffer(GL_ARRAY_BUFFER, gl_vbo);
     glEnableVertexAttribArray(0);
@@ -193,79 +201,14 @@ static void get_window_dimensions(int *w, int *h)
 }
 
 
-static void rebuild_gui_texture(void)
-{
-    SDL_Surface *gui_surface;
-    int prev_w, prev_h, x, y,
-        w, h, depth = LCD_DEPTH < 8 ? 16 : LCD_DEPTH;
-    Uint32 flags = SDL_GetWindowFlags(sdlWindow);
-
-    get_window_dimensions(&w, &h);
-    SDL_RenderGetLogicalSize(sdlRenderer, &prev_w, &prev_h);
-    SDL_RenderSetLogicalSize(sdlRenderer, w, h);
-    if ((gui_texture = SDL_CreateTexture(sdlRenderer, SDL_MasksToPixelFormatEnum(depth,
-                                         0, 0, 0, 0), SDL_TEXTUREACCESS_STREAMING, w, h)) == NULL)
-        panicf("%s", SDL_GetError());
-
-    /* Did background change? */
-    if ((flags & SDL_WINDOW_RESIZABLE) &&
-        !(flags & (SDL_WINDOW_MAXIMIZED | SDL_WINDOW_FULLSCREEN)) &&
-        prev_w && prev_w != w)
-    {
-        SDL_GetWindowSize(sdlWindow, &x, NULL);
-
-        /* Maintain LCD's size */
-        float ratio = (float) x / prev_w;
-        SDL_SetWindowSize(sdlWindow, w * ratio, h * ratio);
-
-        /* move LCD back into previous position */
-        SDL_GetWindowPosition(sdlWindow, &x, &y);
-        if (background)
-        {
-            x -= (UI_LCD_POSX * ratio);
-            y -= (UI_LCD_POSY * ratio);
-        }
-        else
-        {
-            x += (UI_LCD_POSX * ratio);
-            y += (UI_LCD_POSY * ratio);
-        }
-        SDL_SetWindowPosition(sdlWindow, x > 0 ? x : 0, y > 0 ? y : 0);
-    }
-
-    if (background && picture_surface &&
-        (gui_surface = SDL_ConvertSurface(picture_surface, sim_lcd_surface->format, 0)))
-    {
-        SDL_UpdateTexture(gui_texture, NULL, gui_surface->pixels, gui_surface->pitch);
-        SDL_FreeSurface(gui_surface);
-    }
-
-    sdl_gui_update(lcd_surface, 0, 0, SIM_LCD_WIDTH, SIM_LCD_HEIGHT,
-                   SIM_LCD_WIDTH, SIM_LCD_HEIGHT,
-                   background ? UI_LCD_POSX : 0, background? UI_LCD_POSY : 0);
-
-}
-
 void sdl_window_render(void)
 {
     if (trimpod_viz_active)
         return;   /* visualizer owns the GL context/window right now */
+    if (lcd_panel_is_dark())
+        return;   /* panel off: the surfaces stay current, the present is waste */
     sdl_gl_make_current();
     gl_present_lcd_fade(sim_lcd_surface, 1.0f);
-    return;
-    if (new_gui_texture_needed)
-    {
-        new_gui_texture_needed = false;
-        if (gui_texture)
-            SDL_DestroyTexture(gui_texture);
-        rebuild_gui_texture();
-    }
-    else
-    {
-        SDL_RenderClear(sdlRenderer);
-        SDL_RenderCopy(sdlRenderer, gui_texture, NULL, NULL);
-        SDL_RenderPresent(sdlRenderer);
-    }
 }
 
 bool sdl_window_adjust(void)
@@ -288,10 +231,9 @@ bool sdl_window_adjust(void)
     return true;
 }
 
-void sdl_window_adjustment_needed(bool destroy_texture)
+void sdl_window_adjustment_needed(void)
 {
     window_adjustment_needed = true;
-    new_gui_texture_needed = destroy_texture;
 
     /* For MacOS and Windows, we're on a main or
     display thread already, and can immediately
@@ -309,8 +251,9 @@ void sdl_window_setup(void)
     if (display_zoom == 1)
         flags |= SDL_WINDOW_RESIZABLE;
 
-    if (!(picture_surface = SDL_LoadBMP("UI256.bmp")))
-        background = false;
+    /* No window-background bitmap on this target: the LCD fills the window.
+     * (`background` defaults to true, so it must be cleared here.) */
+    background = false;
 
     get_window_dimensions(&width, &height);
 
@@ -337,7 +280,6 @@ void sdl_window_setup(void)
                                                 depth, 0, 0, 0, 0)) == NULL)
         panicf("%s", SDL_GetError());
 
-    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, display_zoom == 1 ? "best" : "nearest");
     display_zoom = 0; /* reset to 0 unless/until user requests a scale level change */
     window_mutex = SDL_CreateMutex();
 }

--- a/firmware/target/hosted/sdl/window-sdl.h
+++ b/firmware/target/hosted/sdl/window-sdl.h
@@ -22,7 +22,6 @@
 
 #include "SDL.h"
 
-extern SDL_Texture *gui_texture; /* Window content, including background */
 extern SDL_Surface *sim_lcd_surface; /* LCD content */
 
 extern SDL_mutex *window_mutex;  /* prevent concurrent drawing from event thread &
@@ -34,10 +33,10 @@ void sdl_window_render(void);
 /* Updates size, aspect ratio, and re-renders window content */
 bool sdl_window_adjust(void);
 
-/* Needs to be called when window size, scale quality, or background should change */
-void sdl_window_adjustment_needed(bool destroy_texture);
+/* Needs to be called when the window size should change */
+void sdl_window_adjustment_needed(void);
 
-/* Creates window, renderer, and LCD surface when app launches */
+/* Creates window, GL context, and LCD surface when app launches */
 void sdl_window_setup(void);
 
 extern SDL_Window *sdlWindow;       /* the app window (GL-enabled on this target) */

--- a/pak.json
+++ b/pak.json
@@ -1,6 +1,6 @@
 {
   "name": "Trimpod Classic",
-  "version": "v1.0.2",
+  "version": "v1.0.3",
   "type": "TOOL",
   "description": "An iPod Classic-inspired, offline music player for the TrimUI Brick/Hammer with winamp-like visualizations.",
   "author": "tyrannotorus",
@@ -13,7 +13,7 @@
   ],
   "platforms": ["tg5040"],
   "changelog": {
-    "v1.0.2": "Japanese song metadata now displays throughout the UI. New Artists/Albums/Songs library browsing backed by a track index, with much faster playback start on large queues. Now Playing: tap A to play/pause, hold A for the menu. Settings values now change in place (no sub-pages). Smarter shuffle: normal plays start in order; only explicit shuffle actions shuffle. New in Settings > Power: battery Charge Limit and CPU frequency control. A-B repeat removed; internal cleanup.",
+    "v1.0.3": "Adjusted volume increments, improved performance by reducing redundant cycle burn, added a controls legend to Settings, various bug fixes.",
     "v1.0.1": "Initial release."
   }
 }

--- a/pak/launch.sh
+++ b/pak/launch.sh
@@ -73,6 +73,13 @@ TRIMPOD_DV="$(amixer sget 'digital volume' 2>/dev/null | sed -n 's/.*Mono: \([0-
 TRIMPOD_DAC="$(amixer sget 'DAC volume' 2>/dev/null | sed -n 's/.*Front Left: \([0-9][0-9]*\).*/\1/p')"
 [ -n "$TRIMPOD_DV" ]  && amixer -q sset 'digital volume' 0   2>/dev/null
 [ -n "$TRIMPOD_DAC" ] && amixer -q sset 'DAC volume'     160 2>/dev/null
+# NextUI at volume 0 (or side-switch mute) ALSO latches the speaker driver's
+# hard mute (/sys/class/speaker/mute), which survives into our session and
+# silences Trimpod regardless of its own volume.  Unmute for the session and
+# restore the user's NextUI state on exit.
+SPK_MUTE=/sys/class/speaker/mute
+TRIMPOD_SPK_MUTE="$(cat "$SPK_MUTE" 2>/dev/null)"
+[ -n "$TRIMPOD_SPK_MUTE" ] && echo 0 > "$SPK_MUTE" 2>/dev/null
 
 # ALL teardown lives here so it runs on every catchable exit path -- a clean
 # binary return, or INT/TERM/HUP (e.g. NextUI stopping the pak) -- not just the
@@ -87,6 +94,7 @@ cleanup() {
   [ -f /tmp/trimpod_muted_vol ] && dd if=/tmp/trimpod_muted_vol of=/dev/shm/SharedSettings bs=1 seek=56 count=4 conv=notrunc 2>/dev/null
   [ -n "$TRIMPOD_DV" ] && amixer -q sset "digital volume" "$TRIMPOD_DV" 2>/dev/null
   [ -n "$TRIMPOD_DAC" ] && amixer -q sset "DAC volume" "$TRIMPOD_DAC" 2>/dev/null
+  [ -n "$TRIMPOD_SPK_MUTE" ] && echo "$TRIMPOD_SPK_MUTE" > "$SPK_MUTE" 2>/dev/null
   if [ -d "$CPUP" ] && [ -n "$TRIMPOD_OLD_GOV" ]; then
     echo 408000 > "$CPUP/scaling_min_freq"
     echo "$TRIMPOD_OLD_MAX" > "$CPUP/scaling_max_freq"

--- a/pak/trimpod/config.cfg
+++ b/pak/trimpod/config.cfg
@@ -4,7 +4,7 @@
 wps: /tmp/trimpod/wps/1ST_GEN_REMIX.wps
 sbs: /tmp/trimpod/wps/1ST_GEN_REMIX.sbs
 font: /tmp/trimpod/fonts/24-ChicagoFLF.fnt
-volume: -22
+volume_ddb: -220
 selector type: bar (inverse)
 backdrop: -
 background color: 637D8C


### PR DESCRIPTION
Volume: 40 even notches

  - 0.1 dB storage resolution (was whole dB, which made every notch uneven); range −80.0…−3.0, default
  −22.0
  - Perceptual steps 20 → 40
  - Fixed a double-width step at the top of the dial (update_norm_tab skipped an index)
  - Config keys versioned volume→volume_ddb, volume limit→volume_limit_ddb, so a pre-update .resume.cfg
  can't be misread as near-max

  New: Settings → Controls

  Reference page listing the four inputs. It and About now set their own header title instead of
  inheriting "Settings".

  Performance

  Music + screen off 931 → 171 ms/s, screen on 890 → 458, idle 105 → 79.

  - No rendering while the panel is dark (gated on the backlight transition; wake presents before
  lighting)
  - SDL_BLENDMODE_NONE on lcd_surface — it has no alpha channel but was blending every frame: 15.11 →
  0.26 ms/frame
  - Zero-copy GL_RGB upload, texture updated in place, channel order via shader swizzle
  - Removed sim_backlight(), the unreachable SDL_Renderer path, and its orphans
